### PR TITLE
Provide a single slot

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: mesa-core20
 base: core20
-adopt-info: mesa
+adopt-info: mesa-lib
 summary: mesa libraries for core20 snaps
 description: |
   A content snap containing the mesa libraries and drivers for core 20
@@ -9,23 +9,31 @@ grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict
 
 parts:
-  mesa:
+  mesa-lib:
     plugin: nil
     override-pull:
       snapcraftctl set-version `LANG=C apt-cache policy libgl1-mesa-dri | sed -rne 's/^\s+Candidate:\s+([^-]*)-.+$/\1/p'`
     stage-packages:
       - libgl1-mesa-dri
     prime:
-      - -lib/udev
-      - -usr/share
+      - egl/lib
+      - -egl/lib/dri
+    organize:
+      usr/lib/${SNAPCRAFT_ARCH_TRIPLET}: egl/lib
+
+  mesa-dri:
+    after:
+      - mesa-lib
+    plugin: nil
+    stage-packages:
+      - libgl1-mesa-dri
+    prime:
+      - egl/dri
+    organize:
+      usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri: egl/dri
 
 slots:
-  egl-libs-core20:
+  egl-core20:
     interface: content
-    read: 
-      - $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}
-
-  egl-dri-core20:
-    interface: content
-    read: 
-      - $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
+    read:
+      - egl

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: mesa-core20
 base: core20
-adopt-info: mesa-lib
+adopt-info: mesa
 summary: mesa libraries for core20 snaps
 description: |
   A content snap containing the mesa libraries and drivers for core 20
@@ -9,28 +9,20 @@ grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict
 
 parts:
-  mesa-lib:
+  mesa:
     plugin: nil
     override-pull:
       snapcraftctl set-version `LANG=C apt-cache policy libgl1-mesa-dri | sed -rne 's/^\s+Candidate:\s+([^-]*)-.+$/\1/p'`
     stage-packages:
       - libgl1-mesa-dri
+    override-build: |
+      snapcraftctl build
+      mkdir -p $SNAPCRAFT_PART_INSTALL/egl/lib
+      mv $SNAPCRAFT_PART_INSTALL/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri $SNAPCRAFT_PART_INSTALL/egl
+      mv $SNAPCRAFT_PART_INSTALL/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/* $SNAPCRAFT_PART_INSTALL/egl/lib
     prime:
       - egl/lib
-      - -egl/lib/dri
-    organize:
-      usr/lib/${SNAPCRAFT_ARCH_TRIPLET}: egl/lib
-
-  mesa-dri:
-    after:
-      - mesa-lib
-    plugin: nil
-    stage-packages:
-      - libgl1-mesa-dri
-    prime:
       - egl/dri
-    organize:
-      usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri: egl/dri
 
 slots:
   egl-core20:


### PR DESCRIPTION
This moves the libs and drivers into a single slot, which is less error prone.

The client needs something like:

```
environment:
  ...
  # Setup EGL from the plugs
  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}:$SNAP/egl/lib
  LIBGL_DRIVERS_PATH: $SNAP/egl/dri

...

plugs:
  ...
  egl-core20:
    interface: content
    target: $SNAP/egl
    default-provider: mesa-core20/edge
```