### PR TITLE
Add va-driver-all

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,7 @@ parts:
       snapcraftctl set-version `LANG=C apt-cache policy libgl1-mesa-dri | sed -rne 's/^\s+Candidate:\s+([^-]*)-.+$/\1/p'`
     stage-packages:
       - libgl1-mesa-dri
+      - va-driver-all
     override-build: |
       snapcraftctl build
       mkdir -p $SNAPCRAFT_PART_INSTALL/egl/lib


### PR DESCRIPTION
Adding the VA drivers isn't needed *for Mir*, but makes sense if we use this with client snaps, or snaps that include other software. It is only 6M, so the flexibility is worth it.

Before: -rw-r--r-- 1 alan alan  32M May 21 12:17 mesa-core20_20.2.6_amd64.snap
After: -rw-r--r-- 1 alan alan  38M May 28 12:56 mesa-core20_20.2.6_amd64.snap
