### PR TITLE
[Merged by Bors] - Add libegl1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,7 @@ parts:
     stage-packages:
       - libgl1-mesa-dri
       - va-driver-all
+      - libegl1
     organize:
       'usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri/*': egl/dri/
       'usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/*.so*': egl/lib/


### PR DESCRIPTION
libEGL.so.1 should be part of graphics-core20 interface as it can be vendor specific