### PR TITLE
[Merged by Bors] - Also publish glvnd info

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This supplies the graphics-core20 content interface:
 
     .../lib contains the mesa shared libraries (add to LD_LIBRARY_PATH)
     .../drv contains the mesa drivers (set LIBGL_DRIVERS_PATH/LIBVA_DRIVERS_PATH to this)
+    .../glvnd/egl_vendor.d contains the mesa ICD (set __EGL_VENDOR_LIBRARY_DIRS to this)
     .../etc/mir-quirks contains any Mir configuration for driver support (none for mesa)
 
 ----

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,9 +28,11 @@ parts:
     organize:
       'usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri/*': egl/dri/
       'usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/*.so*': egl/lib/
+      'usr/share/glvnd': egl/glvnd/
     prime:
       - egl/lib
       - egl/dri
+      - egl/glvnd
 
 slots:
   graphics-core20:


### PR DESCRIPTION
For using the mesa libEGL.so.1 we also need the glvnd ICD for mesa