### PR TITLE
[Merged by Bors] - Add `/usr/share/libdrm/amdgpu.ids`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This supplies the graphics-core20 content interface:
     .../drv contains the mesa drivers (set LIBGL_DRIVERS_PATH/LIBVA_DRIVERS_PATH to this)
     .../glvnd/egl_vendor.d contains the mesa ICD (set __EGL_VENDOR_LIBRARY_DIRS to this)
     .../etc/mir-quirks contains any Mir configuration for driver support (none for mesa)
+    .../libdrm contains mesa configuration for driver support (layout to /usr/share/libdrm) 
 
 ----
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,10 +29,12 @@ parts:
       'usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri/*': egl/dri/
       'usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/*.so*': egl/lib/
       'usr/share/glvnd': egl/glvnd/
+      'usr/share/libdrm': egl/libdrm/
     prime:
       - egl/lib
       - egl/dri
       - egl/glvnd
+      - egl/libdrm
 
 slots:
   graphics-core20:


### PR DESCRIPTION
See discussion here:

https://discourse.ubuntu.com/t/the-graphics-core20-snap-interface/23000/2