### PR TITLE
[Merged by Bors] - Add `/usr/share/drirc.d/00-mesa-defaults.conf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This supplies the graphics-core20 content interface:
     .../glvnd/egl_vendor.d contains the mesa ICD (set __EGL_VENDOR_LIBRARY_DIRS to this)
     .../etc/mir-quirks contains any Mir configuration for driver support (none for mesa)
     .../libdrm contains mesa configuration for driver support (layout to /usr/share/libdrm) 
+    .../drirc.d contains mesa app-specific workarounds (layout to /usr/share/drirc.d) 
 
 ----
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,11 +30,13 @@ parts:
       'usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/*.so*': egl/lib/
       'usr/share/glvnd': egl/glvnd/
       'usr/share/libdrm': egl/libdrm/
+      'usr/share/drirc.d/': egl/drirc.d/
     prime:
       - egl/lib
       - egl/dri
       - egl/glvnd
       - egl/libdrm
+      - egl/drirc.d
 
 slots:
   graphics-core20:


### PR DESCRIPTION
Another hard-coded path in libgl1-mesa-dri