### PR TITLE
Workaround for https://github.com/MirServer/mir/issues/2467

### DIFF
--- a/quirks/etc/mir-quirks
+++ b/quirks/etc/mir-quirks
@@ -1,0 +1,2 @@
+# Mir's gbm-kms support isn't (yet) working with Nvidia
+driver-quirks=skip:driver:nvidia

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,6 +40,12 @@ parts:
       - egl/libdrm
       - egl/drirc.d
 
+  quirks:
+    plugin: dump
+    source: quirks
+    organize:
+      'etc/': egl/etc/
+
 slots:
   graphics-core20:
     interface: content


### PR DESCRIPTION
Add a quirk preventing Mir's gbm-kms support being used for Nvidia cards